### PR TITLE
remove <version>{mavlink.java.version}</version> as support is deprecated in maven

### DIFF
--- a/org.mavlink.generator/pom.xml
+++ b/org.mavlink.generator/pom.xml
@@ -20,7 +20,7 @@
 		<dependency>
 			<groupId>org.mavlink</groupId>
 			<artifactId>org.mavlink.util</artifactId>
-			<version>{mavlink.java.version}</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/org.mavlink.generator/pom.xml
+++ b/org.mavlink.generator/pom.xml
@@ -8,7 +8,6 @@
 		<relativePath>../org.mavlink.maven</relativePath>
 	</parent>
 	<artifactId>org.mavlink.generator</artifactId>
-	<version>{mavlink.java.version}</version>
 	<packaging>jar</packaging>
 	<name>MAVLink Java Generator</name>
 	<description>MAVLink Java code generator for embedded devices or Ground Stations</description>

--- a/org.mavlink.library/pom.xml
+++ b/org.mavlink.library/pom.xml
@@ -41,7 +41,7 @@
 		<dependency>
 			<groupId>org.mavlink</groupId>
 			<artifactId>org.mavlink.util</artifactId>
-			<version>{mavlink.java.version}</version>
+			<version>${project.version}</version>
 		</dependency>
 		<dependency>
 			<groupId>junit</groupId>

--- a/org.mavlink.library/pom.xml
+++ b/org.mavlink.library/pom.xml
@@ -9,7 +9,6 @@
 	</parent>
 	<artifactId>org.mavlink.library</artifactId>
 	<packaging>jar</packaging>
-	<version>{mavlink.java.version}</version>
 	<name>MAVLink Java Library</name>
 	<description>MAVLink Java Library for embedded devices or Ground Stations</description>
 	<url>https://github.com/ghelle/MAVLinkJava</url>

--- a/org.mavlink.util/pom.xml
+++ b/org.mavlink.util/pom.xml
@@ -8,7 +8,6 @@
 		<version>1.0.6</version>
 	</parent>
 	<artifactId>org.mavlink.util</artifactId>
-	<version>{mavlink.java.version}</version>
 	<packaging>jar</packaging>
 	<name>MAVLink Java Tools</name>
 	<description>MAVLink Java CRC calculation and messages interface for embedded devices or Ground Stations</description>


### PR DESCRIPTION
use of properties in <version> tag is considered malformed by maven and support is deprecated/likely dropped in maven 3. Also, <version> can be inherited from parent pom.
